### PR TITLE
Add GitHub Actions for new releases

### DIFF
--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -1,0 +1,64 @@
+name: New Release
+
+env:
+  REGISTRY: ghcr.io
+
+on:
+  release:
+    types: [ published ]
+    # Trigger only when a release with tag v*.*.* is published
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update version in package.json
+        run: |
+          CURRENT_TAG=${GITHUB_REF#refs/tags/}
+          echo "Current tag: $CURRENT_TAG"
+          VERSION="${CURRENT_TAG#v}"
+          echo "Updating version to: $VERSION"
+          jq ".version = \"$VERSION\"" package.json > package.json.tmp
+          mv package.json.tmp package.json
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: Update package.json version
+          branch: update-version
+          commit-message: Update package.json version
+          body: Update the version of `package.json` as part of release process
+          delete-branch: true
+          base: main
+  publish:
+    runs-on: ubuntu-latest
+    needs: update-version
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+
+      - name: Update version in package.json
+        run: |
+          CURRENT_TAG=${GITHUB_REF#refs/tags/}
+          echo "Current tag: $CURRENT_TAG"
+          VERSION="${CURRENT_TAG#v}"
+          echo "Updating version to: $VERSION"
+          jq ".version = \"$VERSION\"" package.json > package.json.tmp
+          mv package.json.tmp package.json
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Publish Package
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 node_modules/
 config.mk
+.idea

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amrc-factoryplus/sparkplug-app",
   "version": "0.0.1",
-  "description": "Sparkplug Application functionality.",
+  "description": "A Javascript library providing Sparkplug Application functionality",
   "main": "lib/index.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
This commit introduces a workflow for handling new releases. It triggers when a release with tag `v*.*.*` is published. The workflow entails updating the version in package.json, creating a pull request for the version update, and finally publishing the packagei on the registry.

Also, improves .gitignore by ignoring .idea files and modifies the description of the package in package.json.