### PR TITLE
Use Rx more intelligently

### DIFF
--- a/lib/sparkplug-app.js
+++ b/lib/sparkplug-app.js
@@ -63,7 +63,9 @@ class SparkplugDevice {
             .pipe(
                 rx.takeUntil(births),
                 rx.tap(() => this.log("Rebirthing %s", addr)),
-                rx.mergeMap(n => rx.from(cmdesc.rebirth(addr))))
+                rx.mergeMap(n => cmdesc.rebirth(addr)
+                    .catch(e => 
+                        this.log("Error rebirthing %s: %s", addr, e))))
             .subscribe();
 
         return births;

--- a/lib/sparkplug-app.js
+++ b/lib/sparkplug-app.js
@@ -14,10 +14,7 @@ class SparkplugDevice {
         this.app = app;
         this.log = this.app.debug.log.bind(this.app.debug, "device");
 
-        this.address = opts.address 
-            ? rx.of(Address.parse(opts.address))
-            : this._setup_address(opts);
-
+        this.address = this._setup_address(opts);
         this.packets = this._setup_packets();
         this.births = this._setup_births();
         this.metrics = this._setup_metrics();
@@ -26,21 +23,23 @@ class SparkplugDevice {
     }
 
     /* XXX This should be more dynamic. In both cases we should be
-     * watching the relevant source of information and restarting our
-     * subscription if the address changes. */
+     * tracking the relevant source of information. */
     _setup_address (opts) {
         const fp = this.app.fplus;
 
         const resolver =
-            opts.node ? fp.ConfigDB
+            opts.address ? rx.of(Address.parse(opts.address))
+            : opts.node ? fp.ConfigDB
                 .get_config(UUIDs.App.SparkplugAddress, opts.node)
                 .then(add => add && new Address(add.group_id, add.node_id))
             : opts.device ? fp.Directory.get_device_address(opts.device)
             : null;
         if (resolver == null)
-            throw "You must provide a device to watch";
+            throw new SPAppError("You must provide a device to watch");
 
-        return rx.from(resolver).pipe(rx.share());
+        /* Return an endless sequence. This is for future compat when we
+         * track the device's address. */
+        return rx.concat(resolver, rx.NEVER).pipe(rx.share());
     }
 
     _setup_packets () {

--- a/lib/sparkplug-app.js
+++ b/lib/sparkplug-app.js
@@ -65,7 +65,10 @@ class SparkplugDevice {
                 rx.tap(() => this.log("Rebirthing %s", addr)),
                 rx.mergeMap(n => cmdesc.rebirth(addr)
                     .catch(e => 
-                        this.log("Error rebirthing %s: %s", addr, e))))
+                        this.log("Error rebirthing %s: %s", addr, e))),
+                /* Give up after 5 minutes and let k8s restart us. */
+                rx.timeout({ first: 5*60*1000 }),
+            )
             .subscribe();
 
         return births;

--- a/lib/sparkplug-app.js
+++ b/lib/sparkplug-app.js
@@ -16,7 +16,7 @@ class SparkplugDevice {
 
         this.address = this._setup_address(opts);
         this.packets = this._setup_packets();
-        this.births = this._setup_births();
+        this.births = this._setup_births(opts.rebirth);
         this.metrics = this._setup_metrics();
 
         return this;
@@ -50,8 +50,11 @@ class SparkplugDevice {
         );
     }
 
-    _setup_births (addr) {
+    _setup_births (opts) {
         const cmdesc = this.app.fplus.CmdEsc;
+
+        const timeout = opts?.timeout ?? 5*60*1000;
+        const rebirth = opts?.interval ?? 2000;
 
         /* XXX We map aliases to strings here. It would be better to map
          * to BigInts, or to have the protobuf decoder decode to BigInts
@@ -69,13 +72,13 @@ class SparkplugDevice {
                         .filter(m => "alias" in m)
                         .map(m => [m.alias.toString(), m.name])),
             })),
-            rx.timeout({ first: 5*60*1000 }),
+            rx.timeout({ first: timeout }),
             rx.shareReplay(1),
             rx.tap(b => this.log("Birth for %s", b.address)));
 
         /* XXX The initial delay here is crude. We should be reacting to
          * successful MQTT subscription instead. */
-        const rebirths = rx.timer(20, 2000)
+        const rebirths = rx.timer(20, rebirth)
             .pipe(
                 rx.takeUntil(births),
                 rx.withLatestFrom(this.address),

--- a/lib/sparkplug-app.js
+++ b/lib/sparkplug-app.js
@@ -14,39 +14,41 @@ class SparkplugDevice {
         this.app = app;
         this.log = this.app.debug.log.bind(this.app.debug, "device");
 
-        if (opts.address) {
-            this.address = opts.address;
-        }
-        else if (opts.node) {
-            this.kind = "Node";
-            this.uuid = opts.node;
-        }
-        else if (opts.device) {
-            this.kind = "Device";
-            this.uuid = opts.device;
-        }
-        else {
-            throw new SPAppError("Must supply device or address to constructor");
-        }
+        this.address = opts.address 
+            ? rx.of(Address.parse(opts.address))
+            : this._setup_address(opts);
+
+        this.packets = this._setup_packets();
+        this.births = this._setup_births();
+        this.metrics = this._setup_metrics();
+
+        return this;
     }
 
     /* XXX This should be more dynamic. In both cases we should be
      * watching the relevant source of information and restarting our
      * subscription if the address changes. */
-    async _address () {
-        const addr = this.address;
-        if (addr instanceof Address) return addr;
-        if (addr != null) return Address.parse(addr);
-
+    _setup_address (opts) {
         const fp = this.app.fplus;
-        const resolved = await this.kind == "Node"
-            ? fp.Auth.find_principal("uuid", this.uuid)
-                .then(ids => ids.sparkplug)
-            : fp.Directory.get_device_address(this.uuid);
 
-        if (!resolved)
-            throw new SPAppError(`Can't resolve ${this.kind} ${this.uuid}`);
-        return resolved;
+        const resolver =
+            opts.node ? fp.ConfigDB
+                .get_config(UUIDs.App.SparkplugAddress, opts.node)
+                .then(add => add && new Address(add.group_id, add.node_id))
+            : opts.device ? fp.Directory.get_device_address(opts.device)
+            : null;
+        if (resolver == null)
+            throw "You must provide a device to watch";
+
+        return rx.from(resolver).pipe(rx.share());
+    }
+
+    _setup_packets () {
+        return this.address.pipe(
+            rx.tap(addr => this.log("Watching %s", addr)),
+            rx.switchMap(addr => this.app.watch_address(addr)),
+            rx.share(),
+        );
     }
 
     _setup_births (addr) {
@@ -59,6 +61,7 @@ class SparkplugDevice {
         const births = this.packets.pipe(
             rx.filter(p => p.type == "BIRTH"),
             rx.map(birth => ({
+                address:        birth.address,
                 factoryplus:    birth.uuid == UUIDs.FactoryPlus,
                 metrics:        new Map(
                     birth.metrics.map(m => [m.name, m])),
@@ -69,13 +72,16 @@ class SparkplugDevice {
             })),
             rx.timeout({ first: 5*60*1000 }),
             rx.shareReplay(1),
-            rx.tap(b => this.log("Birth for %s", addr)));
+            rx.tap(b => this.log("Birth for %s", b.address)));
 
         /* XXX The initial delay here is crude. We should be reacting to
-         * successful subscription instead. */
+         * successful MQTT subscription instead. */
         const rebirths = rx.timer(20, 2000)
-            .pipe(rx.takeUntil(births))
-            .subscribe(() => {
+            .pipe(
+                rx.takeUntil(births),
+                rx.withLatestFrom(this.address),
+            )
+            .subscribe(([ix, addr]) => {
                 this.log("Rebirthing %s", addr);
                 cmdesc.rebirth(addr)
                     .catch(e => this.log("Error rebirthing %s: %s", addr, e));
@@ -101,15 +107,6 @@ class SparkplugDevice {
     }
 
     async init () {
-        const { fplus, mqtt } = this.app;
-
-        const addr = await this._address();
-        this.log("Watching %s", addr);
-
-        this.packets = this.app.watch_address(addr).pipe(rx.share());
-        this.births = this._setup_births(addr);
-        this.metrics = this._setup_metrics();
-
         return this;
     }
 
@@ -149,15 +146,21 @@ export class SparkplugApp {
         return this;
     }
 
+    /* This subscribes to MQTT when the method is called. This is
+     * incorrect: our MQTT subscriptions should be driven by the
+     * sequence subscriptions. */
     watch_address (addr) {
         this.watch.next(addr);
         return this.packets.pipe(
             rx.filter(m => m.topic.address.equals(addr)),
-            rx.map(({topic, payload}) => ({type: topic.type, ...payload})));
+            rx.map(({topic, payload}) => ({
+                type:       topic.type,
+                address:    topic.address,
+                ...payload,
+            })));
     }
 
-    async device (opts) {
-        const dev = new SparkplugDevice(this, opts);
-        return await dev.init();
+    device (opts) {
+        return new SparkplugDevice(this, opts);
     }
 }

--- a/lib/sparkplug-app.js
+++ b/lib/sparkplug-app.js
@@ -14,25 +14,38 @@ class SparkplugDevice {
         this.app = app;
         this.log = this.app.debug.log.bind(this.app.debug, "device");
 
-        if (opts.device) {
-            this.device = opts.device;
-        }
-        else if (opts.address) {
+        if (opts.address) {
             this.address = opts.address;
+        }
+        else if (opts.node) {
+            this.kind = "Node";
+            this.uuid = opts.node;
+        }
+        else if (opts.device) {
+            this.kind = "Device";
+            this.uuid = opts.device;
         }
         else {
             throw new SPAppError("Must supply device or address to constructor");
         }
     }
 
+    /* XXX This should be more dynamic. In both cases we should be
+     * watching the relevant source of information and restarting our
+     * subscription if the address changes. */
     async _address () {
         const addr = this.address;
         if (addr instanceof Address) return addr;
         if (addr != null) return Address.parse(addr);
 
-        const resolved = await this.app.fplus.Directory.get_device_address(this.device);
+        const fp = this.app.fplus;
+        const resolved = await this.kind == "Node"
+            ? fp.Auth.find_principal("uuid", this.uuid)
+                .then(ids => ids.sparkplug)
+            : fp.Directory.get_device_address(this.uuid);
+
         if (!resolved)
-            throw new SPAppError(`Can't resolve device ${this.device}`);
+            throw new SPAppError(`Can't resolve ${this.kind} ${this.uuid}`);
         return resolved;
     }
 

--- a/lib/sparkplug-app.js
+++ b/lib/sparkplug-app.js
@@ -54,22 +54,19 @@ class SparkplugDevice {
                         .filter(m => "alias" in m)
                         .map(m => [m.alias.toString(), m.name])),
             })),
+            rx.timeout({ first: 5*60*1000 }),
             rx.shareReplay(1),
             rx.tap(b => this.log("Birth for %s", addr)));
 
         /* XXX The initial delay here is crude. We should be reacting to
          * successful subscription instead. */
-        rx.timer(20, 2000)
-            .pipe(
-                rx.takeUntil(births),
-                rx.tap(() => this.log("Rebirthing %s", addr)),
-                rx.mergeMap(n => cmdesc.rebirth(addr)
-                    .catch(e => 
-                        this.log("Error rebirthing %s: %s", addr, e))),
-                /* Give up after 5 minutes and let k8s restart us. */
-                rx.timeout({ first: 5*60*1000 }),
-            )
-            .subscribe();
+        const rebirths = rx.timer(20, 2000)
+            .pipe(rx.takeUntil(births))
+            .subscribe(() => {
+                this.log("Rebirthing %s", addr);
+                cmdesc.rebirth(addr)
+                    .catch(e => this.log("Error rebirthing %s: %s", addr, e));
+            });
 
         return births;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amrc-factoryplus/sparkplug-app",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.2",
   "description": "A Javascript library providing Sparkplug Application functionality",
   "main": "lib/index.js",
   "type": "module",


### PR DESCRIPTION
* Timeout waiting for a rebirth. Allow an error down the sequence. Clients can handle this further or just allow it to kill the process. Some errors (bad MQTT permissions) can only be recovered by restarting.
* Support locating a Node address from its preconfigured address in the ConfigDB rather than from the Directory. The edge monitor needs this as a non-functional Edge Agent won't have a Directory entry yet.
* Make a sequence available giving the current address of the device we are watching. This will currently only ever emit one value but it gives an opportunity to track address changes in future.