### PR TITLE
Handle unknown devices better

### DIFF
--- a/lib/sparkplug-device.js
+++ b/lib/sparkplug-device.js
@@ -62,6 +62,8 @@ export class SparkplugDevice {
         return this.address.pipe(
             rx.tap(addr => this.log("Watching %s", addr)),
             rx.switchMap(addr => this.app.watch_address(addr)),
+            rx.tap({ error: e => this.log("Can't watch: %s", e) }),
+            rx.retry({ delay: 10000 }),
             rx.share(),
         );
     }

--- a/lib/sparkplug-device.js
+++ b/lib/sparkplug-device.js
@@ -30,18 +30,18 @@ export class SparkplugDevice {
         const fp = this.app.fplus;
 
         const resolver =
-            opts.address ? rx.of(Address.parse(opts.address))
-            : opts.node ? fp.ConfigDB
+            opts.address ? () => rx.of(Address.parse(opts.address))
+            : opts.node ? () => fp.ConfigDB
                 .get_config(UUIDs.App.SparkplugAddress, opts.node)
                 .then(add => add && new Address(add.group_id, add.node_id))
-            : opts.device ? fp.Directory.get_device_address(opts.device)
+            : opts.device ? () => fp.Directory.get_device_address(opts.device)
             : null;
         if (resolver == null)
             throw new SPAppError("You must provide a device to watch");
 
         /* Return an endless sequence. This is for future compat when we
          * track the device's address. */
-        return rx.from(resolver).pipe(
+        return rx.defer(resolver).pipe(
             rx.filter(a => a != null),
             rx.throwIfEmpty(),
             rx.tap({ error: e => this.log("Can't resolve %o", opts) }),

--- a/lib/sparkplug-device.js
+++ b/lib/sparkplug-device.js
@@ -41,7 +41,12 @@ export class SparkplugDevice {
 
         /* Return an endless sequence. This is for future compat when we
          * track the device's address. */
-        return rx.concat(resolver, rx.NEVER).pipe(
+        return rx.from(resolver).pipe(
+            rx.filter(a => a != null),
+            rx.throwIfEmpty(),
+            rx.tap({ error: e => this.log("Can't resolve %o", opts) }),
+            rx.retry({ delay: 5000 }),
+            rx.concatWith(rx.NEVER),
             /* Ensure new subscribers see the last address. This uses
              * shareReplay for the moment, as we never update the
              * address. When we do it should use rxx.shareLatest. */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amrc-factoryplus/sparkplug-app",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A Javascript library providing Sparkplug Application functionality",
   "main": "lib/index.js",
   "type": "module",
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "@amrc-factoryplus/rx-util": "^0.0.1",
-    "@amrc-factoryplus/utilities": "^1.2.2",
+    "@amrc-factoryplus/utilities": "^1.3.0",
     "rxjs": "^7.8.1"
   }
 }


### PR DESCRIPTION
When we attempt to watch a device and it isn't registered in the services yet, delay and retry instead of pushing an invalid address downstream. This prevents errors later on; in this case the invalid address was causing a fast loop and huge memory consumption, as a downstream sequence ended up retrying without a delay.