### PR TITLE
Support wildcard subscriptions

### DIFF
--- a/lib/sparkplug-app.js
+++ b/lib/sparkplug-app.js
@@ -3,7 +3,8 @@
  * Copyright 2023 AMRC.
  */
 
-import rx from "rxjs";
+import mqtt_match       from "mqtt-match";
+import rx               from "rxjs";
 
 import { SpB, Topic }       from "@amrc-factoryplus/utilities";
 
@@ -66,7 +67,7 @@ export class SparkplugApp {
 
         log("Starting new seq for %s", topic);
         const seq = this.packets.pipe(
-            rx.filter(p => p.topic == topic),
+            rx.filter(p => mqtt_match(topic, p.topic)),
             /* Teardown when we have no more consumers */
             rx.finalize(() => {
                 this.topics.delete(topic);

--- a/lib/sparkplug-device.js
+++ b/lib/sparkplug-device.js
@@ -89,8 +89,8 @@ export class SparkplugDevice {
                         .filter(m => "alias" in m)
                         .map(m => [m.alias.toString(), m.name])),
             })),
-            rxx.shareLatest(),
             rx.tap(b => this.log("Birth for %s", b.address)),
+            rxx.shareLatest(),
         );
 
         return births;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amrc-factoryplus/sparkplug-app",
-  "version": "0.0.4",
+  "version": "0.0.5-bmz1",
   "description": "A Javascript library providing Sparkplug Application functionality",
   "main": "lib/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amrc-factoryplus/sparkplug-app",
-  "version": "0.0.5-bmz1",
+  "version": "0.0.5",
   "description": "A Javascript library providing Sparkplug Application functionality",
   "main": "lib/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "license": "MIT",
   "dependencies": {
     "@amrc-factoryplus/rx-util": "^0.0.1",
-    "@amrc-factoryplus/utilities": "^1.3.0",
+    "@amrc-factoryplus/utilities": "^1.3.2",
+    "mqtt-match": "^3.0.0",
     "rxjs": "^7.8.1"
   }
 }


### PR DESCRIPTION
The logic to filter out the packets belonging to a particular subscription did not account for wildcards.