### PR TITLE
Don't send repeated rebirths

### DIFF
--- a/lib/sparkplug-app.js
+++ b/lib/sparkplug-app.js
@@ -61,11 +61,11 @@ export class SparkplugApp {
         const log = this.debug.log.bind(this.debug, "topic");
 
         if (this.topics.has(topic)) {
-            log("Using cached seq for %s", topic);
+            //log("Using cached seq for %s", topic);
             return this.topics.get(topic);
         }
 
-        log("Starting new seq for %s", topic);
+        //log("Starting new seq for %s", topic);
         const seq = this.packets.pipe(
             rx.filter(p => mqtt_match(topic, p.topic)),
             /* Teardown when we have no more consumers */

--- a/lib/sparkplug-app.js
+++ b/lib/sparkplug-app.js
@@ -4,7 +4,7 @@
  */
 
 import mqtt_match       from "mqtt-match";
-import rx               from "rxjs";
+import * as rx          from "rxjs";
 
 import { SpB, Topic }       from "@amrc-factoryplus/utilities";
 

--- a/lib/sparkplug-app.js
+++ b/lib/sparkplug-app.js
@@ -6,7 +6,7 @@
 import mqtt_match       from "mqtt-match";
 import * as rx          from "rxjs";
 
-import { SpB, Topic }       from "@amrc-factoryplus/utilities";
+import { SpB, Topic }       from "@amrc-factoryplus/service-client";
 
 import { SparkplugDevice }  from "./sparkplug-device.js";
 

--- a/lib/sparkplug-device.js
+++ b/lib/sparkplug-device.js
@@ -4,7 +4,7 @@
  * Copyright 2023 AMRC
  */
 
-import rx from "rxjs";
+import * as rx from "rxjs";
 
 import * as rxx             from "@amrc-factoryplus/rx-util";
 import { Address, UUIDs }   from "@amrc-factoryplus/utilities";

--- a/lib/sparkplug-device.js
+++ b/lib/sparkplug-device.js
@@ -7,7 +7,7 @@
 import * as rx from "rxjs";
 
 import * as rxx             from "@amrc-factoryplus/rx-util";
-import { Address, UUIDs }   from "@amrc-factoryplus/utilities";
+import { Address, UUIDs }   from "@amrc-factoryplus/service-client";
 
 import { SPAppError }       from "./spapp-error.js";
 

--- a/lib/sparkplug-device.js
+++ b/lib/sparkplug-device.js
@@ -76,10 +76,10 @@ export class SparkplugDevice {
          * in the first place, but the only way to convert Longs to
          * BigInts is via a string. */
         const births = this.packets.pipe(
+            /* This is merged in purely as side-effect, so we send a
+             * single rebirth request when we are subscribed to. */
+            rx.mergeWith(this.rebirth()),
             rx.filter(p => p.type == "BIRTH"),
-            /* If we don't get a birth, rebirth and retry */
-            rx.timeout({ first: rebirth }),
-            rx.retry({ delay: e => this.rebirth() }),
             rx.map(birth => ({
                 address:        birth.address,
                 factoryplus:    birth.uuid == UUIDs.FactoryPlus,
@@ -132,16 +132,24 @@ export class SparkplugDevice {
         return this;
     }
 
-    /* Send a rebirth request. */
-    async rebirth () {
-        const addr = await rx.firstValueFrom(this.address);
-        this.log("Rebirthing %s", addr);
-        try {
-            await this.app.fplus.CmdEsc.rebirth(addr);
-        }
-        catch (e) {
-            this.log("Error rebirthing %s: %s", addr, e);
-        }
+    /* Send a rebirth request. It will keep retrying until it has sent
+     * one rebirth request. This returns an Observable so that it can be
+     * cancelled; to actually send the request the returned Observable
+     * must be subscribed to. */
+    rebirth () {
+        const cmdesc = this.app.fplus.CmdEsc;
+        return rxx.rx(
+            this.address,
+            rx.take(1),
+            rx.tap(addr => this.log("Rebirthing %s", addr)),
+            rx.mergeMap(addr => rxx.rx(
+                cmdesc.rebirth(addr),
+                rx.tap({
+                    error: e => this.log("Error rebirthing %s: %s", addr, e),
+                }))),
+            rx.retry({ delay: 5000 }),
+            rx.ignoreElements(),
+        );
     }
 
     metric (tag) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amrc-factoryplus/sparkplug-app",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A Javascript library providing Sparkplug Application functionality",
   "main": "lib/index.js",
   "type": "module",
@@ -11,8 +11,8 @@
   "author": "AMRC",
   "license": "MIT",
   "dependencies": {
-    "@amrc-factoryplus/rx-util": "^0.0.1",
-    "@amrc-factoryplus/service-client": "^1.3.5",
+    "@amrc-factoryplus/rx-util": "^0.0.3",
+    "@amrc-factoryplus/service-client": "^1.3.6",
     "mqtt-match": "^3.0.0",
     "rxjs": "^7.8.1"
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "@amrc-factoryplus/rx-util": "^0.0.1",
-    "@amrc-factoryplus/utilities": "^1.3.2",
+    "@amrc-factoryplus/service-client": "^1.3.5",
     "mqtt-match": "^3.0.0",
     "rxjs": "^7.8.1"
   }


### PR DESCRIPTION
* Don't send more than one rebirth when we read a device. Waking the device up isn't our responsibility.
* Switch to @amrc-factoryplus/service-client instead of /utilities.
* Remove default imports where possible.

Closes: #16
Closes: #17